### PR TITLE
CSV.Create - Converting from JSON to CSV allows users to specify headers manually

### DIFF
--- a/Frends.CSV.Create/CHANGELOG.md
+++ b/Frends.CSV.Create/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.1] - 2024-08-12
+### Added
+- Added option to specify headers manually when creating a CSV from Json.
+
 ## [1.2.0] - 2024-05-06
 ### Added
 - Input Json can be Array or Object

--- a/Frends.CSV.Create/CHANGELOG.md
+++ b/Frends.CSV.Create/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.2.1] - 2024-08-12
+## [1.3.0] - 2024-08-12
 ### Added
 - Added option to specify headers manually when creating a CSV from Json.
 

--- a/Frends.CSV.Create/Frends.CSV.Create.UnitTests/UnitTests.cs
+++ b/Frends.CSV.Create/Frends.CSV.Create.UnitTests/UnitTests.cs
@@ -148,50 +148,38 @@ user2;123322222;user21@frends.com;user22@frends.com;user23@frends.com;;;role2_1;
     }
 
     [TestMethod]
-    public void CreateTest_WriteFromJSONWithManualHeaders()
+    public void CreateTest_WriteFromJSONWithManualColumns()
     {
-        var inputJson = @"
-        [
-            {
-                ""user"": {
-                    ""id"": 1,
-                    ""name"": ""John Doe"",
-                    ""email"": ""john.doe@example.com""
-                },
-                ""account"": {
-                    ""plan"": ""Pro"",
-                    ""balance"": 100.5
-                }
-            },
-            {
-                ""user"": {
-                    ""id"": 2,
-                    ""name"": ""Jane Smith"",
-                    ""email"": ""jane.smith@example.com""
-                },
-                ""account"": {
-                    ""plan"": ""Basic"",
-                    ""balance"": 50.75
-                }
-            }
-        ]";
-
-        var headers = new List<Dictionary<string, string>>
+        var headers = new List<string>
         {
-            new Dictionary<string, string> { { "HeaderName", "User ID" }, { "JsonPath", "$.user.id" } },
-            new Dictionary<string, string> { { "HeaderName", "User Name" }, { "JsonPath", "$.user.name" } },
-            new Dictionary<string, string> { { "HeaderName", "User Email" }, { "JsonPath", "$.user.email" } },
-            new Dictionary<string, string> { { "HeaderName", "Account Plan" }, { "JsonPath", "$.account.plan" } },
-            new Dictionary<string, string> { { "HeaderName", "Account Balance" }, { "JsonPath", "$.account.balance" } }
+            "Login",
+            "Phone",
+            "Primary Email",
+            "Secondary Email",
+            "Role List 1",
+            "Role List 2",
+            "Activation Type"
+        };
+
+        var columns = new List<string>
+        {
+            "$.user_data.login",
+            "$.user_data.phone",
+            "$.user_data.contact.emails[0]",
+            "$.user_data.contact.emails[1]",
+            "$.roles[0].roles_list1[0]",
+            "$.roles[1].roles_list2[0]",
+            "$.activation_type"
         };
 
         var input = new Input()
         {
             InputType = CreateInputType.Json,
             Delimiter = ";",
-            Json = inputJson,
-            SpecifyHeadersManually = true,
-            ManualHeaders = headers
+            Json = _jsonString,
+            SpecifyColumnsManually = true,
+            Headers = headers,
+            Columns = columns
         };
 
         var options = new Options()
@@ -202,14 +190,34 @@ user2;123322222;user21@frends.com;user22@frends.com;user23@frends.com;;;role2_1;
         var result = CSV.Create(input, options, default);
 
         var expectedCsv =
-            $"User ID;User Name;User Email;Account Plan;Account Balance{Environment.NewLine}" +
-            $"1;John Doe;john.doe@example.com;Pro;100.5{Environment.NewLine}" +
-            $"2;Jane Smith;jane.smith@example.com;Basic;50.75{Environment.NewLine}";
+            $"Login;Phone;Primary Email;Secondary Email;Role List 1;Role List 2;Activation Type{Environment.NewLine}" +
+            $"user1;123321111;user11@frends.com;user12@frends.com;role1_1;role2_1;password{Environment.NewLine}" +
+            $"user2;123322222;user21@frends.com;user22@frends.com;;role2_1;password{Environment.NewLine}";
+
 
         Assert.IsTrue(result.Success);
         Assert.AreEqual(expectedCsv, result.CSV);
     }
 
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void CreateExceptionTest_EmptyManualColumns()
+    {
+        var input = new Input()
+        {
+            InputType = CreateInputType.Json,
+            Delimiter = ";",
+            Json = _jsonString,
+            SpecifyColumnsManually = true,
+            Columns = null
+        };
+
+        var options = new Options() { };
+
+        var result = CSV.Create(input, options, default);
+
+        Assert.IsFalse(result.Success);
+    }
 
     [TestMethod]
     public void CreateTest_WriteFromXML()

--- a/Frends.CSV.Create/Frends.CSV.Create.UnitTests/UnitTests.cs
+++ b/Frends.CSV.Create/Frends.CSV.Create.UnitTests/UnitTests.cs
@@ -194,13 +194,14 @@ user2;123322222;user21@frends.com;user22@frends.com;user23@frends.com;;;role2_1;
             ManualHeaders = headers
         };
 
-        var options = new Options() {
+        var options = new Options()
+        {
             IncludeHeaderRow = true
         };
 
         var result = CSV.Create(input, options, default);
 
-        var expectedCsv = 
+        var expectedCsv =
             $"User ID;User Name;User Email;Account Plan;Account Balance{Environment.NewLine}" +
             $"1;John Doe;john.doe@example.com;Pro;100.5{Environment.NewLine}" +
             $"2;Jane Smith;jane.smith@example.com;Basic;50.75{Environment.NewLine}";

--- a/Frends.CSV.Create/Frends.CSV.Create.UnitTests/UnitTests.cs
+++ b/Frends.CSV.Create/Frends.CSV.Create.UnitTests/UnitTests.cs
@@ -148,6 +148,69 @@ user2;123322222;user21@frends.com;user22@frends.com;user23@frends.com;;;role2_1;
     }
 
     [TestMethod]
+    public void CreateTest_WriteFromJSONWithManualHeaders()
+    {
+        var inputJson = @"
+        [
+            {
+                ""user"": {
+                    ""id"": 1,
+                    ""name"": ""John Doe"",
+                    ""email"": ""john.doe@example.com""
+                },
+                ""account"": {
+                    ""plan"": ""Pro"",
+                    ""balance"": 100.5
+                }
+            },
+            {
+                ""user"": {
+                    ""id"": 2,
+                    ""name"": ""Jane Smith"",
+                    ""email"": ""jane.smith@example.com""
+                },
+                ""account"": {
+                    ""plan"": ""Basic"",
+                    ""balance"": 50.75
+                }
+            }
+        ]";
+
+        var headers = new List<Dictionary<string, string>>
+        {
+            new Dictionary<string, string> { { "HeaderName", "User ID" }, { "JsonPath", "$.user.id" } },
+            new Dictionary<string, string> { { "HeaderName", "User Name" }, { "JsonPath", "$.user.name" } },
+            new Dictionary<string, string> { { "HeaderName", "User Email" }, { "JsonPath", "$.user.email" } },
+            new Dictionary<string, string> { { "HeaderName", "Account Plan" }, { "JsonPath", "$.account.plan" } },
+            new Dictionary<string, string> { { "HeaderName", "Account Balance" }, { "JsonPath", "$.account.balance" } }
+        };
+
+        var input = new Input()
+        {
+            InputType = CreateInputType.Json,
+            Delimiter = ";",
+            Json = inputJson,
+            SpecifyHeadersManually = true,
+            ManualHeaders = headers
+        };
+
+        var options = new Options() {
+            IncludeHeaderRow = true
+        };
+
+        var result = CSV.Create(input, options, default);
+
+        var expectedCsv = 
+            $"User ID;User Name;User Email;Account Plan;Account Balance{Environment.NewLine}" +
+            $"1;John Doe;john.doe@example.com;Pro;100.5{Environment.NewLine}" +
+            $"2;Jane Smith;jane.smith@example.com;Basic;50.75{Environment.NewLine}";
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(expectedCsv, result.CSV);
+    }
+
+
+    [TestMethod]
     public void CreateTest_WriteFromXML()
     {
         var input = new Input()

--- a/Frends.CSV.Create/Frends.CSV.Create/Create.cs
+++ b/Frends.CSV.Create/Frends.CSV.Create/Create.cs
@@ -105,7 +105,7 @@ public class CSV
 
         //If headers are specified manually
         if (input.SpecifyHeadersManually && input.ManualHeaders != null && input.ManualHeaders.Any())
-        { 
+        {
             //Write the manually specified header row
             if (config.HasHeaderRecord)
             {

--- a/Frends.CSV.Create/Frends.CSV.Create/Definitions/Input.cs
+++ b/Frends.CSV.Create/Frends.CSV.Create/Definitions/Input.cs
@@ -33,19 +33,19 @@ public class Input
     public string Json { get; set; }
 
     /// <summary>
-    /// If set true, allows the user to manually specify an array of headers which to generate.
+    /// If set true, allows the user to manually specify an array of columns which to generate.
     /// </summary>
     /// <example>false</example>
     [UIHint(nameof(InputType), "", CreateInputType.Json)]
     [DefaultValue("false")]
-    public bool SpecifyHeadersManually { get; set; }
+    public bool SpecifyColumnsManually { get; set; }
 
     /// <summary>
-    /// Custom headers for the data.
+    /// Custom columns for the data.
     /// </summary>
-    /// <example>{ Values, Foos, Bars, Dates }</example>
-    [UIHint(nameof(SpecifyHeadersManually), "", true)]
-    public List<Dictionary<string, string>> ManualHeaders { get; set; }
+    /// <example>{ "Column1", "Column2", "Column3" }</example>
+    [UIHint(nameof(SpecifyColumnsManually), "", true)]
+    public List<string> Columns { get; set; }
 
     /// <summary>
     /// Xml string to write to CSV. 

--- a/Frends.CSV.Create/Frends.CSV.Create/Definitions/Input.cs
+++ b/Frends.CSV.Create/Frends.CSV.Create/Definitions/Input.cs
@@ -33,6 +33,21 @@ public class Input
     public string Json { get; set; }
 
     /// <summary>
+    /// If set true, allows the user to manually specify an array of headers which to generate.
+    /// </summary>
+    /// <example>false</example>
+    [UIHint(nameof(InputType), "", CreateInputType.Json)]
+    [DefaultValue("false")]
+    public bool SpecifyHeadersManually { get; set; }
+
+    /// <summary>
+    /// Custom headers for the data.
+    /// </summary>
+    /// <example>{ Values, Foos, Bars, Dates }</example>
+    [UIHint(nameof(SpecifyHeadersManually), "", true)]
+    public List<Dictionary<string, string>> ManualHeaders { get; set; }
+
+    /// <summary>
     /// Xml string to write to CSV. 
     /// </summary>
     /// <example>

--- a/Frends.CSV.Create/Frends.CSV.Create/Frends.CSV.Create.csproj
+++ b/Frends.CSV.Create/Frends.CSV.Create/Frends.CSV.Create.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>1.2.0</Version>
+	<Version>1.3.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>


### PR DESCRIPTION
Closes #31 . This change allows specifying the headers manually. For each header the user is able to specify the header name (for use in output CSV) and the JSON path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Users can now manually specify headers when creating a CSV file from JSON data, offering enhanced flexibility in defining the CSV structure.
- **Bug Fixes**
	- Improved robustness of CSV creation logic by adding new tests for handling user-defined columns and headers, ensuring accurate CSV output.
- **Documentation**
	- Changelog updated to reflect the new version (1.3.0) and its features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->