### PR TITLE
CSV.Create - Bug fix: Fixed issue with empty spaces in JSON property names

### DIFF
--- a/Frends.CSV.Create/CHANGELOG.md
+++ b/Frends.CSV.Create/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.5.0] - 2024-10-11
+### Fixed
+- Fixed issue with JSON properties having spaces in property names.
+
 ## [1.4.0] - 2024-08-20
 ### Added
 - Updated NewtonSoft.Json to the latest version 13.0.3.

--- a/Frends.CSV.Create/Frends.CSV.Create.UnitTests/UnitTests.cs
+++ b/Frends.CSV.Create/Frends.CSV.Create.UnitTests/UnitTests.cs
@@ -467,4 +467,22 @@ bar
             result.CSV
         );
     }
+
+    [TestMethod]
+    public void CreateTest_JSONWithSpacesInPropertyNames()
+    {
+        var json = @"{ ""property with spaces"": ""test test"" }";
+
+        var input = new Input()
+        {
+            InputType = CreateInputType.Json,
+            Delimiter = ";",
+            Json = json
+        };
+
+        var options = new Options() { };
+
+        var result = CSV.Create(input, options, default);
+        Assert.IsFalse(result.CSV.Contains("['property with spaces']"));
+    }
 }

--- a/Frends.CSV.Create/Frends.CSV.Create.UnitTests/UnitTests.cs
+++ b/Frends.CSV.Create/Frends.CSV.Create.UnitTests/UnitTests.cs
@@ -482,7 +482,38 @@ bar
 
         var options = new Options() { };
 
+        var expectedCsv = $"property with spaces{Environment.NewLine}test test{Environment.NewLine}";
+
         var result = CSV.Create(input, options, default);
-        Assert.IsFalse(result.CSV.Contains("['property with spaces']"));
+
+        Console.WriteLine(result.CSV);
+        Assert.AreEqual(expectedCsv, result.CSV);
+    }
+
+    [TestMethod]
+    public void CreateTest_JSONWithSpacesInPropertyNames2()
+    {
+        var json = @"{
+        ""property with spaces"": ""test test"",
+        ""normal_property"": ""value"",
+        ""another property with spaces"": 123
+    }";
+
+        var input = new Input()
+        {
+            InputType = CreateInputType.Json,
+            Delimiter = ";",
+            Json = json
+        };
+
+        var options = new Options() { };
+
+        var result = CSV.Create(input, options, default);
+
+        Assert.IsTrue(result.Success);
+
+        var expectedCsv = $"property with spaces;normal_property;another property with spaces{Environment.NewLine}test test;value;123{Environment.NewLine}";
+
+        Assert.AreEqual(expectedCsv, result.CSV);
     }
 }

--- a/Frends.CSV.Create/Frends.CSV.Create/Create.cs
+++ b/Frends.CSV.Create/Frends.CSV.Create/Create.cs
@@ -12,6 +12,7 @@ using CsvHelper.Configuration;
 using Frends.CSV.Create.Definitions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace Frends.CSV.Create;
 
@@ -285,7 +286,7 @@ public class CSV
                                 foreach (JToken child in jToken.Parent!.Children())
                                 {
                                     properties.Add(
-                                        child.Path,
+                                        child.Path.Replace("['", "").Replace("']", ""),
                                         child.Type == JTokenType.Null ? null : child.ToString()
                                     );
                                 }
@@ -301,7 +302,7 @@ public class CSV
                         {
                             //adding non-array properties
                             properties.Add(
-                                jToken.Path,
+                                jToken.Path.Replace("['", "").Replace("']", ""),
                                 jToken.Type == JTokenType.Null ? null : jToken.ToString()
                             );
                         }

--- a/Frends.CSV.Create/Frends.CSV.Create/Create.cs
+++ b/Frends.CSV.Create/Frends.CSV.Create/Create.cs
@@ -12,7 +12,6 @@ using CsvHelper.Configuration;
 using Frends.CSV.Create.Definitions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace Frends.CSV.Create;
 

--- a/Frends.CSV.Create/Frends.CSV.Create/Frends.CSV.Create.csproj
+++ b/Frends.CSV.Create/Frends.CSV.Create/Frends.CSV.Create.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>1.4.0</Version>
+	<Version>1.5.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>


### PR DESCRIPTION
#38 

## [1.5.0] - 2024-10-11
### Fixed
- Fixed issue with JSON properties having spaces in property names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes for Version 1.5.0

- **New Features**
	- Improved handling of JSON properties with spaces during CSV creation.
	- Enhanced error handling for manually specified columns to prevent invalid input.

- **Bug Fixes**
	- Resolved issues with JSON properties containing spaces, ensuring cleaner CSV output.

- **Tests**
	- Added two new tests to verify correct handling of JSON with spaces in property names.

- **Chores**
	- Updated version number to 1.5.0 in the project file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->